### PR TITLE
Do not install fuse

### DIFF
--- a/personal_infra/puppet/modules/workstation/manifests/init.pp
+++ b/personal_infra/puppet/modules/workstation/manifests/init.pp
@@ -1,5 +1,5 @@
 class workstation {
-  package {['pipx', 'rclone', 'fuse', 'rsync', 'sshpass', 'bash-completion', 'python3-pip']:}
+  package {['pipx', 'rclone', 'rsync', 'sshpass', 'bash-completion', 'python3-pip']:}
 
   if ($facts['os']['family'] == 'Debian') {
     file {'/etc/apt/keyrings/packages.mozilla.org.asc':


### PR DESCRIPTION
It removes Gnome in Debian. Plus it was only needed to run the Emacs appimage which I don't use anymore.