### PR TITLE
Evolve the plan against the current web and the content web manifesto

### DIFF
--- a/IDEAS.org
+++ b/IDEAS.org
@@ -64,37 +64,7 @@ This is basically a hybrid of https://linuxcontainers.org/incus/ and https://pro
   - VPN interfaces
   -  Reverse proxies
 
-* Simpler web
-
-- https://www.fixbrowser.org/
-
-** Document how terminal browsers can invoke a full browser to execute JavaScript
-
-See [[https://www.gnu.org/software/emacs/manual/html_node/eww/Advanced.html]], w3m has similar stuff.
-
-Also:
-
-- https://github.com/abhinavsingh/proxy.py Extensible Python proxy
-- https://github.com/TempoWorks/txtdot
-- https://github.com/4383/photonos
-- https://sr.ht/%7Ebptato/chawan/
-- https://offpunk.net/
-
-Browsers as a platform to manage content:
-
-- Just view the content as HTML with user-defined styling
-- Archive all that we see so that we can locate content we have read easily, share with others, etc.
-- RSS/Gemfeed/content subscription
-
-** Annotate URLs with another URLs
-
-- For example, add transcriptions to comic strips that do not have them
-- The server pushes serialized bloom filters of annotated URLs (or entire annotation sets?) so that clients do not have to leak what they are browsing.
-- Maybe https://dokie.li/
-- Alternative approach with Violentmonkey for accessibility purposes: [[https://github.com/alexpdp7/aelevenymonkey]].
-
-** NoScript configuration merge
-
+* [[programming/the-content-web-manifesto/README.md][Simpler web]]
 * Typing database
 
 - A database of keyboard layouts.

--- a/misc/problemas.md
+++ b/misc/problemas.md
@@ -70,4 +70,4 @@ Firefox es cada vez más minoritario e irrelevante [aunque yo lo uso y animo a t
 La sofisticación y complejidad de Chrome y Safari adicionalmente hacen que cada vez existan más webs y aplicaciones web que son prácticamente inutilizables en dispositivos de rendimiento modesto.
 Esto hace que sea virtualmente necesario renovar nuestros dispositivos con más frecuencia de la necesaria, a dispositivos más costosos de lo que necesitaríamos para el resto de nuestros propósitos.
 
-He escrito más sobre el tema en inglés en [A plan against the current web](../programming/a_plan_against_the_current_web.md).
+He escrito más sobre el tema en inglés en [a plan against the current web](../programming/a_plan_against_the_current_web.md) y [the content web manifesto](../programming/the-content-web-manifesto/README.md).

--- a/programming/a_plan_against_the_current_web.md
+++ b/programming/a_plan_against_the_current_web.md
@@ -6,26 +6,7 @@ This complexity is derived from using the web for delivering applications, where
 
 ## Part I: Make content websites simple again
 
-Nowadays you cannot use "simple" browsers like Lynx, Dillo, etc. conveniently to browse content.
-You will run into pages which are not usable without a fast and sophisticated Javascript engine, or without a fully-featured web renderer.
-The most common example are websites that are just a blank page when viewed with a browser with Javascript disabled.
-
-If users could browse content using simple browsers, then the power of Chrome would decrease.
-Also, content sites which are usable with simple browsers in my opinion have a nicer user experience: faster, lighter, more accessible, and more flexible.
-
-This is in part impossible nowadays due to the popularity of Javascript-first websites developed as SPAs, and the fall from popularity of progressive enhancement.
-But you can do your part: ensure that you test your content website using a low-powered browser.
-Not Chrome, not Firefox, not Safari; use Dillo, Lynx, etc. to verify that your website works.
-
-This will not move the needle, but your normal users (those who use Chrome) will benefit too.
-
-### Diversion: Gemini
-
-Yes, I cannot avoid talking about Gemini.
-Gemini is this idea driven to the extreme.
-It's an alternative to web browsers and HTML which is so simple that you can implement a Gemini browser in a weekend.
-Of course, it is so extreme that it cannot be a mainstream success.
-But it is an insightful study about these ideas that can be analyzed to learn.
+See [the content web manifesto](the-content-web-manifesto).
 
 ## Part II: Application distribution sucks
 

--- a/programming/the-content-web-manifesto/NOTES.org
+++ b/programming/the-content-web-manifesto/NOTES.org
@@ -1,0 +1,30 @@
+* [[README.md][README]]
+
+- https://www.fixbrowser.org/
+
+** Document how terminal browsers can invoke a full browser to execute JavaScript
+
+See [[https://www.gnu.org/software/emacs/manual/html_node/eww/Advanced.html]], w3m has similar stuff.
+
+Also:
+
+- https://github.com/abhinavsingh/proxy.py Extensible Python proxy
+- https://github.com/TempoWorks/txtdot
+- https://github.com/4383/photonos
+- https://sr.ht/%7Ebptato/chawan/
+- https://offpunk.net/
+
+Browsers as a platform to manage content:
+
+- Just view the content as HTML with user-defined styling
+- Archive all that we see so that we can locate content we have read easily, share with others, etc.
+- RSS/Gemfeed/content subscription
+
+** Annotate URLs with another URLs
+
+- For example, add transcriptions to comic strips that do not have them
+- The server pushes serialized bloom filters of annotated URLs (or entire annotation sets?) so that clients do not have to leak what they are browsing.
+- Maybe https://dokie.li/
+- Alternative approach with Violentmonkey for accessibility purposes: [[https://github.com/alexpdp7/aelevenymonkey]].
+
+** NoScript configuration merge

--- a/programming/the-content-web-manifesto/README.md
+++ b/programming/the-content-web-manifesto/README.md
@@ -4,30 +4,48 @@ These are my recommendations for creating "content" websites.
 In a content website visitors mostly read content.
 Some example content websites are Wikipedia, news websites, and blogs.
 
+Also see [further notes](NOTES.org).
+
 ## General guidelines
 
-### Make content usable without JavaScript
+### Test your website with a terminal browser without JavaScript like w3m, lynx, or elinks
 
-By making your content usable without JavaScript, a content website automatically addresses most annoyances with content websites.
+If your website works with one of those browsers, then:
 
-Websites that do not require JavaScript tend to require less resources, making them faster and lighter.
+* Your website does not require JavaScript to load.
+  This automatically addresses most annoyances with content websites.
+  Websites that do not require JavaScript tend to require less resources, making them faster and lighter.
 
-### Avoid relying on non-text content
+* Your website does not rely on non-text content.
+  Text content is uniquely flexible, it is frequently the most amenable media to being processed by the following systems and processes:
 
-Text content is uniquely flexible, it is frequently the most amenable media to being processed by the following systems and processes:
+  * Text-to-speech systems
+  * Translation (both human and automatic)
+  * Edition (making changes to text content)
+  * Quoting/embedding (readers can copy parts of your text to cite or promote your content)
 
-* Text-to-speech systems
-* Translation (both human and automatic)
-* Edition (making changes to text content)
-* Quoting/embedding (readers can copy parts of your text to cite or promote your content)
+  Images, audio, video or other interactive media might be required to convey the message of your content.
+  Therefore, the content web manifesto does not forbid their use.
+  However, non-text content should always be accompanied by at least a text description of the content, and ideally, an alternate text version of the content.
 
-Images, audio, video or other interactive media might be required to convey the message of your content.
-Therefore, the content web manifesto does not forbid their use.
-However, non-text content should always be accompanied by at least a text description of the content, and ideally, an alternate text version of the content.
+* Your website will work with user styling.
+  Providing a visual style via CSS and others is fine, but users should be able to read your content with *their* choice of font, text size, color, and others.
+  This is important for accessibility, but also for everyone's comfort.
+
+And more importantly, this weakens browser monopolies controlling the web.
+Not even massive companies like Microsoft dare to maintain a browser engine, leaving the web subject to the power of the very few browser vendors in existence.
+But if your web content can be read under a terminal browser without Javascript, then your content is automatically accessible by a massive amount of browsers, including very simple ones.
+
+(Alternatively, use [the Gemini protocol](https://geminiprotocol.net/).)
 
 ### Provide granular URLs
 
 When providing a significant amount of content, make sure readers can link to specific content of interest.
+
+This can be achieved by:
+
+* Splitting your content in different pages
+* Providing HTML headers with anchors
 
 ### Date content
 


### PR DESCRIPTION
* Simplify the content web manifesto to "terminal non-JS browsers"
* Move stuff from the plan against the current web into the content web manifesto
* Centralize links in other content to both documents
* Move from IDEAS.org to programming/the-content-web-manifesto/NOTES.org